### PR TITLE
Lots of enhancements and fix to issue #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# main executable on linux
+terraform-provider-ldap

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Terraform LDAP [![CircleCI](https://circleci.com/gh/Pryz/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/Pryz/terraform-provider-ldap)
+# Terraform LDAP 
+
+[![CircleCI](https://circleci.com/gh/Pryz/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/Pryz/terraform-provider-ldap)
 
 ## Installation
 
@@ -13,7 +15,7 @@ Then add the plugin to your local `.terraformrc` :
 ```
 cat >> ~/.terraformrc <<EOF
 providers {
-  ldap = "${GOPATH}/bin/terraform-provider-ldap"
+    ldap = "${GOPATH}/bin/terraform-provider-ldap"
 }
 EOF
 ```
@@ -22,11 +24,11 @@ EOF
 
 ```
 provider "ldap" {
-  ldap_host = "ldap.mydomain.com"
-  ldap_port = 689
-  use_tls = true
-  bind_user = "foo"
-  bind_password = "bar"
+    ldap_host = "ldap.example.org"
+    ldap_port = 389
+    use_tls = true
+    bind_user = "cn=admin,dc=example,dc=com"
+    bind_password = "admin"
 }
 ```
 
@@ -34,45 +36,42 @@ provider "ldap" {
 
 ```
 resource "ldap_object" "foo" {
-  dn = "uid=foo"
-  base_dn = "dc=example,dc=com"
+    # DN must be complete (no RDN!)
+    dn = "uid=foo,dc=example,dc=com"
 
-  object_classes = [
-    "inetOrgPerson",
-    "posixAccount",
-  ]
+    # classes are specified as an array
+    object_classes = [
+        "inetOrgPerson",
+        "posixAccount",
+    ]
 
-  attribute {
-    name = "sn"
-    value = "10"
-  }
-  attribute {
-    name = "cn"
-    value = "bar"
-  }
-  attribute {
-    name = "uidNumber"
-    value = "1234"
-  }
-  attribute {
-    name = "gidNumber"
-    value = "1234"
-  }
-  attribute {
-    name = "homeDirectory"
-    value = "/home/billy"
-  }
-  attribute {
-    name = "loginShell"
-    value = "/bin/bash"
-  }
-
+    # attributes are sepcified as a set of 1-element maps
+    attributes = [
+        { sn              = "10" },
+        { cn              = "bar" },
+        { uidNumber       = "1234" },
+        { gidNumber       = "1234" },
+        { homeDirectory   = "/home/billy" },
+        { loginShell      = "/bin/bash" },
+        # when an attribute has multiple values, it must be specified multiple times
+        { mail            = "billy@example.com" },
+        { mail            = "admin@example.com" },
+    ]
 }
 ```
 
-Of course the Bind User will need write access.
+The Bind User must have write access for resource creation to succeed.
+
+## Features
+
+This provider is feature complete; it supports resource creation, reading, update 
+and deletion; it can be used to create nested resources at all levels of the
+hierarchy, provided the proper (implicit or explicit) dependencies are declared.
+When it comes to updating an object, the plugin will calculate the set of 
+attributes that need to be added, modified and removed and will surgically 
+operate on the remote object.
 
 ## Limitations
 
-Currently this provider doesn't handle updates. To change records it will delete and create a new one.
-I don't see any problem by doing that for the moment. If you do feel free to create me an Issue.
+This provider supports TLS, but certificate verification is not enabled yet; all
+connections are through TCP, no UDP support yet.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ resource "ldap_object" "foo" {
         "posixAccount",
     ]
 
-    # attributes are sepcified as a set of 1-element maps
+    # attributes are specified as a set of 1-element maps
     attributes = [
         { sn              = "10" },
         { cn              = "bar" },

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Terraform LDAP 
 
-[![CircleCI](https://circleci.com/gh/dihedron/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/dihedron/terraform-provider-ldap)
+[![CircleCI](https://circleci.com/gh/Pryz/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/Pryz/terraform-provider-ldap)
 
 ## Installation
 
 You can easily install the latest version with the following :
 
 ```
-go get -u github.com/dihedron/terraform-provider-ldap
+go get -u github.com/Pryz/terraform-provider-ldap
 ```
 
 Then add the plugin to your local `.terraformrc` :

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Terraform LDAP 
 
-[![CircleCI](https://circleci.com/gh/Pryz/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/Pryz/terraform-provider-ldap)
+[![CircleCI](https://circleci.com/gh/dihedron/terraform-provider-ldap.svg?style=svg)](https://circleci.com/gh/dihedron/terraform-provider-ldap)
 
 ## Installation
 
 You can easily install the latest version with the following :
 
 ```
-go get -u github.com/Pryz/terraform-provider-ldap
+go get -u github.com/dihedron/terraform-provider-ldap
 ```
 
 Then add the plugin to your local `.terraformrc` :
@@ -64,12 +64,27 @@ The Bind User must have write access for resource creation to succeed.
 
 ## Features
 
-This provider is feature complete; it supports resource creation, reading, update 
-and deletion; it can be used to create nested resources at all levels of the
-hierarchy, provided the proper (implicit or explicit) dependencies are declared.
-When it comes to updating an object, the plugin will calculate the set of 
-attributes that need to be added, modified and removed and will surgically 
-operate on the remote object.
+This provider is feature complete.
+As of the latest release, it supports resource creation, reading, update, deletion
+and importing.
+It can be used to create nested resources at all levels of the hierarchy, 
+provided the proper (implicit or explicit) dependencies are declared.
+When updating an object, the plugin computes the minimum set of attributes that 
+need to be added, modified and removed and surgically operates on the remote 
+object to bring it up to date.
+When importing existing LDAP objects into the Terraform state, the plugin can
+automatically generate a .tf file with the relevant information, so that the 
+following ```terraform apply``` does not drop the imported resource out of the
+remote LDAP server due to it missing in the local ```.tf``` files.
+In order to have the plugin generate this file, put the name of the output file
+(which must *not* exist on disk) in the ```TF_LDAP_IMPORTER_PATH``` environment 
+variable, like this:
+```
+$> export TF_LDAP_IMPORTER_PATH=a123456.tf 
+$> terraform import ldap_object.a123456 uid=a123456,ou=users,dc=example,dc=com
+```
+and the plugin will create the ```a123456.tf``` file with the proper information.
+Then merge this file into your existing ```.tf``` file(s).
 
 ## Limitations
 

--- a/config.go
+++ b/config.go
@@ -7,37 +7,38 @@ import (
 	"gopkg.in/ldap.v2"
 )
 
+// Config is the set of parameters needed to configure the LDAP provider.
 type Config struct {
-	LdapHost     string
-	LdapPort     int
+	LDAPHost     string
+	LDAPPort     int
 	UseTLS       bool
 	BindUser     string
 	BindPassword string
 }
 
 func (c *Config) initiateAndBind() (*ldap.Conn, error) {
-	//TODO: Should we handle UDP ?
-	conn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", c.LdapHost, c.LdapPort))
+	// TODO: should we handle UDP ?
+	connection, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", c.LDAPHost, c.LDAPPort))
 	if err != nil {
 		return nil, err
 	}
 
-	// Handle TLS
+	// handle TLS
 	if c.UseTLS {
 		//TODO: Finish the TLS integration
-		err = conn.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		err = connection.StartTLS(&tls.Config{InsecureSkipVerify: true})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Bind to current connection
-	err = conn.Bind(c.BindUser, c.BindPassword)
+	// bind to current connection
+	err = connection.Bind(c.BindUser, c.BindPassword)
 	if err != nil {
-		conn.Close()
+		connection.Close()
 		return nil, err
 	}
 
-	// Return the LDAP connection
-	return conn, nil
+	// return the LDAP connection
+	return connection, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// Provider creates a new LDAP provider.
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -12,71 +13,55 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_HOST", nil),
-				Description: descriptions["ldap_host"],
+				Description: "The LDAP server to connect to.",
 			},
 			"ldap_port": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_PORT", 389),
-				Description: descriptions["ldap_port"],
+				Description: "The LDAP protocol port (default: 389).",
 			},
 			"use_tls": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_USE_TLS", true),
-				Description: descriptions["ldap_port"],
+				Description: "Use TLS to secure the connection (default: true).",
 			},
 			"bind_user": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_BIND_USER", nil),
-				Description: descriptions["bind_user"],
+				Description: "Bind user to be used for authenticating on the LDAP server.",
 			},
 			"bind_password": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LDAP_BIND_PASSWORD", nil),
-				Description: descriptions["bind_password"],
+				Description: "Password to authenticate the Bind user.",
 			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"ldap_object": resourceLdapObject(),
+			"ldap_object": resourceLDAPObject(),
 		},
 
 		ConfigureFunc: configureProvider,
 	}
 }
 
-var descriptions map[string]string
-
-func init() {
-	descriptions = map[string]string{
-		"ldap_host": "The LDAP host to initiate the connection.",
-
-		"ldap_port": "The LDAP port to initiate the connection. Default: 389.",
-
-		"use_tls": "Use TLS to secure the connection. Default: true.",
-
-		"bind_user": "Bind user to be used for the LDAP request.",
-
-		"bind_password": "Password to authenticate the Bind user.",
-	}
-}
-
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		LdapHost:     d.Get("ldap_host").(string),
-		LdapPort:     d.Get("ldap_port").(int),
+		LDAPHost:     d.Get("ldap_host").(string),
+		LDAPPort:     d.Get("ldap_port").(int),
 		UseTLS:       d.Get("use_tls").(bool),
 		BindUser:     d.Get("bind_user").(string),
 		BindPassword: d.Get("bind_password").(string),
 	}
 
-	conn, err := config.initiateAndBind()
+	connection, err := config.initiateAndBind()
 	if err != nil {
 		return nil, err
 	}
 
-	return conn, nil
+	return connection, nil
 }

--- a/resource_ldap_object.go
+++ b/resource_ldap_object.go
@@ -20,6 +20,10 @@ func resourceLDAPObject() *schema.Resource {
 		Delete: resourceLDAPObjectDelete,
 		Exists: resourceLDAPObjectExists,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceLDAPObjectImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"dn": &schema.Schema{
 				Type:        schema.TypeString,
@@ -54,6 +58,12 @@ func resourceLDAPObject() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceLDAPObjectImport(d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
+	err = resourceLDAPObjectRead(d, meta)
+	imported = append(imported, d)
+	return
 }
 
 func resourceLDAPObjectExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {

--- a/resource_ldap_object.go
+++ b/resource_ldap_object.go
@@ -90,19 +90,6 @@ func resourceLDAPObjectExists(d *schema.ResourceData, meta interface{}) (b bool,
 		return false, err
 	}
 
-	/*
-		// the following checks should not be needed
-		if len(sr.Entries) == 0 {
-			log.Printf("[DEBUG] ldap_object::exists - no results for %q", dn)
-			return false, nil
-		} else if len(sr.Entries) > 1 {
-			// this cannot be: we're searching by primary key!
-			log.Printf("[ERROR] ldap_object::exists - more than one result found for %q (?!?!)", dn)
-			err = errors.New("More than one record found for " + dn)
-			return false, err
-		}
-	*/
-
 	log.Printf("[DEBUG] ldap_object::exists - object %q exists", dn)
 	return true, nil
 }
@@ -140,20 +127,6 @@ func resourceLDAPObjectCreate(d *schema.ResourceData, meta interface{}) error {
 				for name, value := range attribute.(map[string]interface{}) {
 					log.Printf("[DEBUG] ldap_object::create - %q has attribute[%v] => %v (%T)", dn, name, value, value)
 					m[name] = append(m[name], value.(string))
-					/*
-						switch value := value.(type) {
-						default:
-							log.Printf("[ERROR] unexpected type %T for attribute %s", value, name)
-						case string:
-							log.Printf("[DEBUG] attribute %q has string value %q", name, value)
-							m[name] = append(m[name], value)
-						case []string:
-							// each value should only be a string, if there is a []string
-							// we have a bug, but let's play it safe anyway...
-							log.Printf("[WARN] attribute %q has []string value %v", name, value)
-							m[name] = append(m[name], value...)
-						}
-					*/
 				}
 			}
 			// now loop through the map and add attributes with theys value(s)
@@ -210,20 +183,6 @@ func resourceLDAPObjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] ldap_object::read - query for %q returned %v", dn, sr)
-
-	/*
-		// these checks should not be necessary
-		if len(sr.Entries) == 0 {
-			// we should never get here!
-			log.Printf("[WARN] ldap_object::read - removing object %q from state because it no longer exists in LDAP", dn)
-			d.SetId("")
-			return nil
-		} else if len(sr.Entries) > 1 {
-			// nor should we ever see this: we're searching by primary key
-			err = errors.New("More than one record found for " + dn)
-			return err
-		}
-	*/
 
 	d.SetId(dn)
 	d.Set("object_classes", sr.Entries[0].GetAttributeValues("objectClass"))
@@ -351,7 +310,6 @@ func attributeHash(v interface{}) int {
 	buffer.WriteRune('}')
 	text := buffer.String()
 	hash := hashcode.String(text)
-	//log.Printf("[DEBUG] ldap_object::diff - hash of %q: %d", text, hash)
 	return hash
 }
 

--- a/resource_ldap_object.go
+++ b/resource_ldap_object.go
@@ -1,186 +1,459 @@
 package main
 
 import (
-	"errors"
-	"fmt"
+	"bytes"
 	"log"
-	"math/rand"
+
+	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/ldap.v2"
 )
 
-func resourceLdapObject() *schema.Resource {
+func resourceLDAPObject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLdapObjectCreate,
-		Read:   resourceLdapObjectRead,
-		//Update: resourceLdapObjectUpdate,
-		Delete: resourceLdapObjectDelete,
-		Exists: resourceLdapObjectExists,
+		Create: resourceLDAPObjectCreate,
+		Read:   resourceLDAPObjectRead,
+		Update: resourceLDAPObjectUpdate,
+		Delete: resourceLDAPObjectDelete,
+		Exists: resourceLDAPObjectExists,
 
 		Schema: map[string]*schema.Schema{
 			"dn": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"base_dn": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Description: "The Distinguished Name (DN) of the object, as the concatenation of its RDN (unique among siblings) and its parent's DN.",
+				Required:    true,
+				ForceNew:    true,
 			},
 			"object_classes": &schema.Schema{
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeSet,
+				Description: "The set of classes this object conforms to (e.g. organizationalUnit, inetOrgPerson).",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Required:    true,
 			},
-			"attribute": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"value": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
+			"attributes": &schema.Schema{
+				Type:        schema.TypeSet,
+				Description: "The map of attributes of this object; each attribute can be multi-valued.",
+				Set:         attributeHash,
+				MinItems:    0,
+
+				Elem: &schema.Schema{
+					Type:        schema.TypeMap,
+					Description: "The list of values for a given attribute.",
+					MinItems:    1,
+					MaxItems:    1,
+					Elem: &schema.Schema{
+						Type:        schema.TypeString,
+						Description: "The individual value for the given attribute.",
 					},
 				},
+				Optional: true,
 			},
 		},
 	}
 }
 
-func resourceLdapObjectExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
+func resourceLDAPObjectExists(d *schema.ResourceData, meta interface{}) (b bool, e error) {
 	conn := meta.(*ldap.Conn)
 	dn := d.Get("dn").(string)
-	base_dn := d.Get("base_dn").(string)
 
-	searchRequest := ldap.NewSearchRequest(
-		base_dn,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(%s)", dn),
+	log.Printf("[DEBUG] ldap_object::exists - checking if %q exists", dn)
+
+	// search by primary key (that is, set the DN as base DN and use a "base
+	// object" scope); no attributes are retrieved since we are onòy checking
+	// for existence; all objects have an "objectClass" attribute, so the filter
+	// is a "match all"
+	request := ldap.NewSearchRequest(
+		dn,
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		0,
+		0,
+		false,
+		"(objectClass=*)",
 		nil,
 		nil,
 	)
 
-	sr, err := conn.Search(searchRequest)
+	_, err := conn.Search(request)
 	if err != nil {
+		if err, ok := err.(*ldap.Error); ok {
+			if err.ResultCode == 32 { // no such object
+				log.Printf("[WARN] ldap_object::exists - lookup for %q returned no value: deleted on server?", dn)
+				return false, nil
+			}
+		}
+		log.Printf("[DEBUG] ldap_object::exists - lookup for %q returned an error %v", dn, err)
 		return false, err
 	}
 
-	if len(sr.Entries) == 0 {
-		return false, nil
-	} else if len(sr.Entries) > 1 {
-		err = errors.New("More than one record found for " + dn)
-		return false, err
-	}
+	/*
+		// the following checks should not be needed
+		if len(sr.Entries) == 0 {
+			log.Printf("[DEBUG] ldap_object::exists - no results for %q", dn)
+			return false, nil
+		} else if len(sr.Entries) > 1 {
+			// this cannot be: we're searching by primary key!
+			log.Printf("[ERROR] ldap_object::exists - more than one result found for %q (?!?!)", dn)
+			err = errors.New("More than one record found for " + dn)
+			return false, err
+		}
+	*/
 
+	log.Printf("[DEBUG] ldap_object::exists - object %q exists", dn)
 	return true, nil
 }
 
-func resourceLdapObjectCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*ldap.Conn)
+func resourceLDAPObjectCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ldap.Conn)
 	dn := d.Get("dn").(string)
-	base_dn := d.Get("base_dn").(string)
 
-	addRequest := ldap.NewAddRequest(fmt.Sprintf("%s,%s", dn, base_dn))
+	log.Printf("[DEBUG] ldap_object::create - creating a new object under %q", dn)
 
+	request := ldap.NewAddRequest(dn)
+
+	// retrieve classe from HCL
 	objectClasses := []string{}
-	for _, oc := range d.Get("object_classes").([]interface{}) {
+	for _, oc := range (d.Get("object_classes").(*schema.Set)).List() {
+		log.Printf("[DEBUG] ldap_object::create - object %q has class: %q", dn, oc.(string))
 		objectClasses = append(objectClasses, oc.(string))
 	}
-	addRequest.Attribute("objectClass", objectClasses)
+	request.Attribute("objectClass", objectClasses)
 
-	if attributes := d.Get("attribute").(*schema.Set); attributes.Len() > 0 {
-		for _, attr := range attributes.List() {
-			m := attr.(map[string]interface{})
-			addRequest.Attribute(m["name"].(string), []string{m["value"].(string)})
+	// if there is a non empty list of attributes, loop though it and
+	// create a new map collecting attribute names and its value(s); we need to
+	// do this because we could not model the attributes as a map[string][]string
+	// due to an appareent limitation in HCL; we have a []map[string]string, so
+	// we loop through the list and accumulate values when they share the same
+	// key, then we use these as attributes in the LDAP client.
+	if v, ok := d.GetOk("attributes"); ok {
+		attributes := v.(*schema.Set).List()
+		if len(attributes) > 0 {
+			log.Printf("[DEBUG] ldap_object::create - object %q has %d attributes", dn, len(attributes))
+			m := make(map[string][]string)
+			for _, attribute := range attributes {
+				log.Printf("[DEBUG] ldap_object::create - %q has attribute of type %T", dn, attribute)
+				// each map should only have one entry (see resource declaration)
+				for name, value := range attribute.(map[string]interface{}) {
+					log.Printf("[DEBUG] ldap_object::create - %q has attribute[%v] => %v (%T)", dn, name, value, value)
+					m[name] = append(m[name], value.(string))
+					/*
+						switch value := value.(type) {
+						default:
+							log.Printf("[ERROR] unexpected type %T for attribute %s", value, name)
+						case string:
+							log.Printf("[DEBUG] attribute %q has string value %q", name, value)
+							m[name] = append(m[name], value)
+						case []string:
+							// each value should only be a string, if there is a []string
+							// we have a bug, but let's play it safe anyway...
+							log.Printf("[WARN] attribute %q has []string value %v", name, value)
+							m[name] = append(m[name], value...)
+						}
+					*/
+				}
+			}
+			// now loop through the map and add attributes with theys value(s)
+			for name, values := range m {
+				request.Attribute(name, values)
+			}
 		}
 	}
 
-	err := conn.Add(addRequest)
+	err := client.Add(request)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%d", rand.Int()))
-	return nil
+	log.Printf("[DEBUG] ldap_object::create - object %q added to LDAP server", dn)
+
+	d.SetId(dn)
+	return resourceLDAPObjectRead(d, meta)
 }
 
-func resourceLdapObjectRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*ldap.Conn)
+func resourceLDAPObjectRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ldap.Conn)
 	dn := d.Get("dn").(string)
-	base_dn := d.Get("base_dn").(string)
 
-	searchRequest := ldap.NewSearchRequest(
-		base_dn,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(%s)", dn),
+	log.Printf("[DEBUG] ldap_object::read - looking for object %q", dn)
+
+	// when searching by DN, you don't need t specify the base DN a search
+	// filter a "subtree" scope: just put the DN (i.e. the primary key) as the
+	// base DN with a "base object" scope, and the returned object will be the
+	// entry, if it exists
+	request := ldap.NewSearchRequest(
+		dn,
+		ldap.ScopeBaseObject,
+		ldap.NeverDerefAliases,
+		0,
+		0,
+		false,
+		"(objectclass=*)",
 		[]string{"*"},
 		nil,
 	)
 
-	sr, err := conn.Search(searchRequest)
+	sr, err := client.Search(request)
 	if err != nil {
+		if err, ok := err.(*ldap.Error); ok {
+			if err.ResultCode == 32 { // no such object
+				log.Printf("[WARN] ldap_object::read - object not found, removing %q from state because it no longer exists in LDAP", dn)
+				d.SetId("")
+				return nil
+			}
+		}
+		log.Printf("[DEBUG] ldap_object::read - lookup for %q returned an error %v", dn, err)
 		return err
 	}
 
-	if len(sr.Entries) == 0 {
-		err = errors.New("No record found for " + dn)
-		return err
-	} else if len(sr.Entries) > 1 {
-		err = errors.New("More than one record found for " + dn)
-		return err
+	log.Printf("[DEBUG] ldap_object::read - query for %q returned %v", dn, sr)
+
+	/*
+		// these checks should not be necessary
+		if len(sr.Entries) == 0 {
+			// we should never get here!
+			log.Printf("[WARN] ldap_object::read - removing object %q from state because it no longer exists in LDAP", dn)
+			d.SetId("")
+			return nil
+		} else if len(sr.Entries) > 1 {
+			// nor should we ever see this: we're searching by primary key
+			err = errors.New("More than one record found for " + dn)
+			return err
+		}
+	*/
+
+	d.SetId(dn)
+	d.Set("object_classes", sr.Entries[0].GetAttributeValues("objectClass"))
+
+	// now deal with attributes
+	set := &schema.Set{
+		F: attributeHash,
 	}
 
-	objectClasses := sr.Entries[0].GetAttributeValues("objectClass")
-	d.Set("object_classes", objectClasses)
-
-	defaultAttr := strings.Split(dn, "=")[0]
-
-	attrMap := make(map[string]map[string]interface{})
-	for _, attr := range sr.Entries[0].Attributes {
-		if attr.Name == "objectClass" || attr.Name == defaultAttr {
+	for _, attribute := range sr.Entries[0].Attributes {
+		log.Printf("[DEBUG] ldap_object::read - treating attribute %q of %q (%d values: %v)", attribute.Name, dn, len(attribute.Values), attribute.Values)
+		if attribute.Name == "objectClass" {
+			// skip: we don't treat object classes as ordinary attributes
+			log.Printf("[DEBUG] ldap_object::read - skipping attribute %q of %q", attribute.Name, dn)
 			continue
 		}
-		k := fmt.Sprintf("%s-%s", attr.Name, attr.Values[0])
-		m := make(map[string]interface{})
-		m["name"] = attr.Name
-		m["value"] = attr.Values[0]
-		attrMap[k] = m
+		if len(attribute.Values) == 1 {
+			// we don't treat the RDN as an ordinary attribute
+			a := fmt.Sprintf("%s=%s", attribute.Name, attribute.Values[0])
+			if strings.HasPrefix(dn, a) {
+				log.Printf("[DEBUG] ldap_object::read - skipping RDN %q of %q", a, dn)
+				continue
+			}
+		}
+		log.Printf("[DEBUG] ldap_object::read - adding attribute %q to %q (%d values)", attribute.Name, dn, len(attribute.Values))
+		// now add each value as an individual entry into the object, because
+		// we do not handle name => []values, and we have a set of maps each
+		// holding a single entry name => value; multiple maps may share the
+		// same key.
+		for _, value := range attribute.Values {
+			log.Printf("[DEBUG] ldap_object::read - for %q, setting %q => %q", dn, attribute.Name, value)
+			set.Add(map[string]interface{}{
+				attribute.Name: value,
+			})
+		}
 	}
 
-	attributes := make([]map[string]interface{}, 0, len(attrMap))
-	for _, m := range attrMap {
-		attributes = append(attributes, m)
+	if err := d.Set("attributes", set); err != nil {
+		log.Printf("[WARN] ldap_object::read - error setting LDAP attributes for %q : %v", dn, err)
+		return err
 	}
-
-	if err := d.Set("attribute", attributes); err != nil {
-		log.Printf("[WARN] Error setting LDAP attributes for (%s) : %s", d.Id(), err)
-	}
-
 	return nil
 }
 
-func resourceLdapObjectDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*ldap.Conn)
-	dn := d.Get("dn").(string)
-	base_dn := d.Get("base_dn").(string)
+func resourceLDAPObjectUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ldap.Conn)
 
-	delRequest := ldap.NewDelRequest(fmt.Sprintf("%s,%s", dn, base_dn), nil)
+	log.Printf("[DEBUG] ldap_object::update - performing update on %q", d.Id())
 
-	err := conn.Del(delRequest)
+	request := ldap.NewModifyRequest(d.Id())
+
+	// handle objectClasses
+	if d.HasChange("object_classes") {
+		classes := []string{}
+		for _, oc := range (d.Get("object_classes").(*schema.Set)).List() {
+			classes = append(classes, oc.(string))
+		}
+		log.Printf("[DEBUG] ldap_object::update - updating classes of %q, new value: %v", d.Id(), classes)
+		request.ReplaceAttributes = []ldap.PartialAttribute{
+			ldap.PartialAttribute{
+				Type: "objectClass",
+				Vals: classes,
+			},
+		}
+	}
+
+	if d.HasChange("attributes") {
+
+		o, n := d.GetChange("attributes")
+		log.Printf("[DEBUG] ldap_object::update - \n%s", printAttributes("old attributes map", o))
+		log.Printf("[DEBUG] ldap_object::update - \n%s", printAttributes("new attributes map", n))
+
+		added, changed, removed := computeDeltas(o.(*schema.Set), n.(*schema.Set))
+		if len(added) > 0 {
+			log.Printf("[DEBUG] ldap_object::update - %d attributes added", len(added))
+			request.AddAttributes = added
+		}
+		if len(changed) > 0 {
+			log.Printf("[DEBUG] ldap_object::update - %d attributes changed", len(changed))
+			if request.ReplaceAttributes == nil {
+				request.ReplaceAttributes = changed
+			} else {
+				request.ReplaceAttributes = append(request.ReplaceAttributes, changed...)
+			}
+		}
+		if len(removed) > 0 {
+			log.Printf("[DEBUG] ldap_object::update - %d attributes removed", len(removed))
+			request.DeleteAttributes = removed
+		}
+	}
+
+	err := client.Modify(request)
 	if err != nil {
+		log.Printf("[ERROR] ldap_object::update - error modifying LDAP object %q with values %v", d.Id(), err)
 		return err
 	}
+	return resourceLDAPObjectRead(d, meta)
+}
+
+func resourceLDAPObjectDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ldap.Conn)
+	dn := d.Get("dn").(string)
+
+	log.Printf("[DEBUG] ldap_object::delete - removing %q", dn)
+
+	request := ldap.NewDelRequest(dn, nil)
+
+	err := client.Del(request)
+	if err != nil {
+		log.Printf("[ERROR] ldap_object::delete - error removing %q: %v", dn, err)
+		return err
+	}
+	log.Printf("[DEBUG] ldap_object::delete - %q removed", dn)
 	return nil
+}
+
+// computes the hash of the map representing an attribute in the attributes set
+func attributeHash(v interface{}) int {
+	m := v.(map[string]interface{})
+	var buffer bytes.Buffer
+	buffer.WriteString("map {")
+	for k, v := range m {
+		buffer.WriteString(fmt.Sprintf("%q := %q;", k, v.(string)))
+	}
+	buffer.WriteRune('}')
+	text := buffer.String()
+	hash := hashcode.String(text)
+	//log.Printf("[DEBUG] ldap_object::diff - hash of %q: %d", text, hash)
+	return hash
+}
+
+func printAttributes(prefix string, attributes interface{}) string {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("%s: {\n", prefix))
+	if attributes, ok := attributes.(*schema.Set); ok {
+		for _, attribute := range attributes.List() {
+			for k, v := range attribute.(map[string]interface{}) {
+				buffer.WriteString(fmt.Sprintf("    %q: %q\n", k, v.(string)))
+			}
+		}
+		buffer.WriteRune('}')
+	}
+	return buffer.String()
+}
+
+func computeDeltas(os, ns *schema.Set) (added, changed, removed []ldap.PartialAttribute) {
+
+	rk := NewSet() // names of removed attributes
+	for _, v := range os.Difference(ns).List() {
+		for k := range v.(map[string]interface{}) {
+			rk.Add(k)
+		}
+	}
+
+	ak := NewSet() // names of added attributes
+	for _, v := range ns.Difference(os).List() {
+		for k := range v.(map[string]interface{}) {
+			ak.Add(k)
+		}
+	}
+
+	kk := NewSet() // names of kept attributes
+	for _, v := range ns.Intersection(os).List() {
+		for k := range v.(map[string]interface{}) {
+			kk.Add(k)
+		}
+	}
+
+	ck := NewSet() // names of changed attributes
+
+	// loop over remove attributes' names
+	for _, k := range rk.List() {
+		if !ak.Contains(k) && !kk.Contains(k) {
+			// one value under this name has been removed, no other value has
+			// been added back, and there is no further value under the same
+			// name among those that were untouched; this means that it has
+			// been dropped and must go among the RemovedAttributes
+			log.Printf("[DEBUG} ldap_object::deltas - dropping attribute %q", k)
+			removed = append(removed, ldap.PartialAttribute{
+				Type: k,
+				Vals: []string{},
+			})
+		} else {
+			ck.Add(k)
+		}
+	}
+
+	for _, k := range ak.List() {
+		if !rk.Contains(k) && !kk.Contains(k) {
+			// this is the first value under this name: no value is being
+			// removed and no value is being kept; so we're adding this new
+			// attribute to the LDAP object (AddedAttributes), getting all
+			// the values under this name from the new set
+			values := []string{}
+			for _, m := range ns.List() {
+				for mk, mv := range m.(map[string]interface{}) {
+					if k == mk {
+						values = append(values, mv.(string))
+					}
+				}
+			}
+			added = append(added, ldap.PartialAttribute{
+				Type: k,
+				Vals: values,
+			})
+			log.Printf("[DEBUG} ldap_object::deltas - adding new attribute %q with values %v", k, values)
+		} else {
+			ck.Add(k)
+		}
+	}
+
+	// now loop over changed attributes and
+	for _, k := range ck.List() {
+		// the attributes in this set have been changed, in that a new value has
+		// been added or removed and it was not the last/first one; so we're
+		// adding this new attribute to the LDAP object (ModifiedAttributes),
+		// getting all the values under this name from the new set
+		values := []string{}
+		for _, m := range ns.List() {
+			for mk, mv := range m.(map[string]interface{}) {
+				if k == mk {
+					values = append(values, mv.(string))
+				}
+			}
+		}
+		changed = append(added, ldap.PartialAttribute{
+			Type: k,
+			Vals: values,
+		})
+		log.Printf("[DEBUG} ldap_object::deltas - changing attribute %q with values %v", k, values)
+	}
+	return
 }

--- a/resource_ldap_object_test.go
+++ b/resource_ldap_object_test.go
@@ -40,8 +40,8 @@ func testAccCheckLdapObjectDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ldap.Conn)
 	for _, r := range s.RootModule().Resources {
 		dn := r.Primary.Attributes["dn"]
-		base_dn := r.Primary.Attributes["base_dn"]
-		sr, err := helperSearchRequest(dn, base_dn, conn)
+		baseDN := r.Primary.Attributes["base_dn"]
+		sr, err := helperSearchRequest(dn, baseDN, conn)
 		if err != nil {
 			return err
 		}
@@ -58,8 +58,8 @@ func testAccCheckLdapObjectExists(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ldap.Conn)
 		for _, r := range s.RootModule().Resources {
 			dn := r.Primary.Attributes["dn"]
-			base_dn := r.Primary.Attributes["base_dn"]
-			sr, err := helperSearchRequest(dn, base_dn, conn)
+			baseDn := r.Primary.Attributes["base_dn"]
+			sr, err := helperSearchRequest(dn, baseDn, conn)
 			if err != nil {
 				return err
 			}
@@ -86,17 +86,14 @@ func testAccCheckLdapObjectAttributes(n string) resource.TestCheckFunc {
 
 const testAccCheckLdapObjectConfig = `
 resource "ldap_object" "foo" {
-  dn = "uid=foo"
-  base_dn = "dc=example,dc=com"
-
+  dn = "uid=foo,dc=example,dc=com"
   object_classes = [
     "inetOrgPerson",
     "posixAccount",
   ]
 
-  attribute {
-    name = "sn"
-    value = "10"
+  attributes = [
+		{ sn = "10"
   }
   attribute {
     name = "cn"
@@ -122,13 +119,7 @@ resource "ldap_object" "foo" {
 }
 `
 
-func helperSearchRequest(dn string, base_dn string, conn *ldap.Conn) (*ldap.SearchResult, error) {
-	searchRequest := ldap.NewSearchRequest(
-		base_dn,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(%s)", dn),
-		[]string{"*"},
-		nil,
-	)
+func helperSearchRequest(dn string, baseDn string, conn *ldap.Conn) (*ldap.SearchResult, error) {
+	searchRequest := ldap.NewSearchRequest(baseDn, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false, fmt.Sprintf("(%s)", dn), []string{"*"}, nil)
 	return conn.Search(searchRequest)
 }

--- a/set.go
+++ b/set.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+// Set represents a set of strings.
+type Set struct {
+	data map[string]struct{}
+}
+
+// NewSet creates a new string set.
+func NewSet(values ...string) *Set {
+	set := &Set{
+		data: map[string]struct{}{},
+	}
+	for _, value := range values {
+		set.Add(value)
+	}
+	return set
+}
+
+// Add adds a string to the set, returning whether the string was actually added;
+// if the same value was already in the set, it will therefore return false.
+func (s *Set) Add(attribute string) bool {
+	if attribute == "" {
+		return false
+	}
+	_, ok := s.data[attribute]
+	if !ok {
+		s.data[attribute] = struct{}{}
+		return true
+	}
+	return false
+}
+
+// Remove removes the given value from the set, returning if such a value was
+// present and therefore actually removed.
+func (s *Set) Remove(attribute string) bool {
+	if attribute == "" {
+		return false
+	}
+	_, ok := s.data[attribute]
+	if ok {
+		delete(s.data, attribute)
+		return true
+	}
+	return false
+}
+
+// Clear removes all values from the set.
+func (s *Set) Clear() {
+	for k := range s.data {
+		delete(s.data, k)
+	}
+}
+
+// Equals checks if two sets have the same elements.
+func (s *Set) Equals(other *Set) bool {
+	if other == nil {
+		return false
+	}
+	if s.Len() != other.Len() {
+		return false
+	}
+	for k := range s.data {
+		if !other.Contains(k) {
+			return false
+		}
+	}
+	return true
+}
+
+// Contains checks if the set contains the given value.
+func (s *Set) Contains(value string) bool {
+	if value == "" {
+		return false
+	}
+	_, ok := s.data[value]
+	return ok
+}
+
+// Len returns the number of elements in the set.
+func (s *Set) Len() int {
+	return len(s.data)
+}
+
+// Difference compares the set against another one and returns a new set
+// containing the elements that are only in this set.
+func (s *Set) Difference(other *Set) *Set {
+	if other == nil {
+		return nil
+	}
+	result := &Set{
+		data: map[string]struct{}{},
+	}
+	for k := range s.data {
+		if !other.Contains(k) {
+			result.Add(k)
+		}
+	}
+	return result
+}
+
+// Intersection compares the set against another one, returning a new set
+// containing only the elements that are in both.
+func (s *Set) Intersection(other *Set) *Set {
+	if other == nil {
+		return nil
+	}
+	result := &Set{
+		data: map[string]struct{}{},
+	}
+	for k := range s.data {
+		if other.Contains(k) {
+			result.Add(k)
+		}
+	}
+	return result
+}
+
+// Union returns a new set containing the elements in the set and in the other
+// set.
+func (s *Set) Union(other *Set) *Set {
+	if other == nil {
+		return nil
+	}
+	result := &Set{
+		data: map[string]struct{}{},
+	}
+	for k := range s.data {
+		result.Add(k)
+	}
+	for k := range other.data {
+		result.Add(k)
+	}
+	return result
+}
+
+// SymmetricDifference compares the set agains the other one and returns a new
+// set containing only the elements that are not in common.
+func (s *Set) SymmetricDifference(other *Set) *Set {
+	if other == nil {
+		return nil
+	}
+	result := &Set{
+		data: map[string]struct{}{},
+	}
+	for k := range s.data {
+		if !other.Contains(k) {
+			result.Add(k)
+		}
+	}
+	for k := range other.data {
+		if !s.Contains(k) {
+			result.Add(k)
+		}
+	}
+	return result
+}
+
+// List returns the elements in the set as a slice of strings.
+func (s *Set) List() []string {
+	sorted := make([]string, 0, s.Len())
+	for k := range s.data {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	return sorted
+}
+
+// String returns a string representation of the set.
+func (s *Set) String() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("{ ")
+	sorted := make([]string, 0, s.Len())
+	for k := range s.data {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+	for _, k := range sorted {
+		buffer.WriteString(fmt.Sprintf("%q, ", k))
+	}
+	buffer.WriteRune('}')
+	return buffer.String()
+}

--- a/set_test.go
+++ b/set_test.go
@@ -2,8 +2,8 @@ package main
 
 import "testing"
 
-func setup() (*set, *set) {
-	s1 := &set{
+func setup() (*Set, *Set) {
+	s1 := &Set{
 		data: map[string]struct{}{},
 	}
 	s1.Add("a")
@@ -27,7 +27,7 @@ func setup() (*set, *set) {
 }
 
 func TestAdd(t *testing.T) {
-	s1 := &set{
+	s1 := &Set{
 		data: map[string]struct{}{},
 	}
 	if !s1.Add("a") {

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,118 @@
+package main
+
+import "testing"
+
+func setup() (*set, *set) {
+	s1 := &set{
+		data: map[string]struct{}{},
+	}
+	s1.Add("a")
+	s1.Add("b")
+	s1.Add("c")
+	s1.Add("d")
+
+	s1.Add("e")
+	s1.Add("f")
+
+	s2 := NewSet()
+	s2.Add("a")
+	s2.Add("b")
+	s2.Add("c")
+	s2.Add("d")
+
+	s2.Add("g")
+	s2.Add("h")
+
+	return s1, s2
+}
+
+func TestAdd(t *testing.T) {
+	s1 := &set{
+		data: map[string]struct{}{},
+	}
+	if !s1.Add("a") {
+		t.Errorf("Invalid result (false) from add of a new string")
+	}
+	if s1.Add("a") != false {
+		t.Error("Invalid result (true) from add of an existing string")
+	}
+	if s1.Add("") != false {
+		t.Error("Invalid result (true) from add of a null string")
+	}
+}
+
+func TestIntersection(t *testing.T) {
+	s1, s2 := setup()
+	intersection := s1.Intersection(s2)
+	if intersection.Len() != 4 {
+		t.Errorf("Invalid intersection, expected 4 got %d", intersection.Len())
+	}
+	for _, v := range []string{"a", "b", "c", "d"} {
+		if !intersection.Contains(v) {
+			t.Errorf("Invalid intersection, it does not contain %q", v)
+		}
+	}
+}
+
+func TestDifference(t *testing.T) {
+	s1, s2 := setup()
+	difference := s1.Difference(s2)
+	if difference.Len() != 2 {
+		t.Errorf("Invalid difference, expected 2 got %d", difference.Len())
+	}
+	for _, v := range []string{"e", "f"} {
+		if !difference.Contains(v) {
+			t.Errorf("Invalid difference, it does not contain %q", v)
+		}
+	}
+
+	difference = s2.Difference(s1)
+	if difference.Len() != 2 {
+		t.Errorf("Invalid difference, expected 2 got %d", difference.Len())
+	}
+	for _, v := range []string{"g", "h"} {
+		if !difference.Contains(v) {
+			t.Errorf("Invalid difference, it does not contain %q", v)
+		}
+	}
+}
+
+func TestUnion(t *testing.T) {
+	s1, s2 := setup()
+	union := s1.Union(s2)
+	if union.Len() != 8 {
+		t.Errorf("Invalid union, expected 8 got %d", union.Len())
+	}
+	for _, v := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		if !union.Contains(v) {
+			t.Errorf("Invalid union, it does not contain %q", v)
+		}
+	}
+}
+
+func TestSymmetricDifference(t *testing.T) {
+	s1, s2 := setup()
+	simmetric := s1.SymmetricDifference(s2)
+	if simmetric.Len() != 4 {
+		t.Errorf("Invalid simmetric difference, expected 4 got %d", simmetric.Len())
+	}
+	for _, v := range []string{"e", "f", "g", "h"} {
+		if !simmetric.Contains(v) {
+			t.Errorf("Invalid simmetric difference, it does not contain %q", v)
+		}
+	}
+}
+
+func TestAllTogether(t *testing.T) {
+	s1, s2 := setup()
+	if !s1.Union(s2).Difference(s1.Intersection(s2)).Equals(s1.SymmetricDifference(s2)) {
+		t.Errorf("Invalid overall concatenation")
+	}
+}
+
+func TestToString(t *testing.T) {
+	s1, _ := setup()
+	if s1.String() != "{ \"a\", \"b\", \"c\", \"d\", \"e\", \"f\", }" {
+		t.Errorf("Invalid string, got %s", s1.String())
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,10 @@
 # Testing
 
 ```
-docker-compose up
+sudo docker-compose up
 terraform plan
 ```
+Then point your browser to http://localhost:6443 and login with username
+"cn=admin,dc=example,dc=com" and password "admin"; the application of the
+main.tf terraform file creates an OU called "users", then create a user under
+that OU.

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,11 +2,21 @@ version: '2'
 services:
   openldap:
     environment:
-      LDAP_ORGANISATION: "Example Inc"
+      LDAP_ORGANISATION: "Example Inc."
       LDAP_DOMAIN: "example.com"
       LDAP_ADMIN_PASSWORD: "admin"
       LDAP_CONFIG_PASSWORD: "config"
-    image: osixia/openldap
+    image: osixia/openldap:latest
     ports:
       - "389:389"
       - "636:636"
+    expose:
+      - "389"
+  phpldapadmin:
+    depends_on:
+      - openldap
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: "openldap"
+    image: osixia/phpldapadmin:latest
+    ports:
+      - "6443:443"

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -1,43 +1,50 @@
+/*
+ * LDAP is the OpenLDAP server.
+ */
 provider "ldap" {
-  ldap_host = "localhost"
-  ldap_port = 389
-  use_tls = false
-  bind_user = "cn=admin,dc=example,dc=com"
-  bind_password = "admin"
+	ldap_host           = "localhost"
+	ldap_port 		   	= 389
+	use_tls 		    = false
+	bind_user 		   	= "cn=admin,dc=example,dc=com"
+	bind_password       = "admin"
 }
 
-resource "ldap_object" "foo" {
-  dn = "uid=foo"
-  base_dn = "dc=example,dc=com"
+/*
+ * Set up an OU to contain users first.
+ *
+ * NOTE: objects are identified by DN; BaseDN is not necessary since the
+ * Terraform LDAP Provider looks up objects by primary key (DN); attributes are
+ * optional, if the object's class does not require them. 
+ */ 
+resource "ldap_object" "users_example_com" {
+	dn 					= "ou=users,dc=example,dc=com"
+	object_classes 	    = [ "top", "organizationalUnit" ]
+# 	object_classes      = [ "organizationalUnit" ]
+}
 
-  object_classes = [
-    "inetOrgPerson",
-    "posixAccount",
-  ]
-
-  attribute {
-    name = "sn"
-    value = "10"
-  }
-  attribute {
-    name = "cn"
-    value = "bar"
-  }
-  attribute {
-    name = "uidNumber"
-    value = "1234"
-  }
-  attribute {
-    name = "gidNumber"
-    value = "1234"
-  }
-  attribute {
-    name = "homeDirectory"
-    value = "/home/billy"
-  }
-  attribute {
-    name = "loginShell"
-    value = "/bin/bash"
-  }
-
+/*
+ * Set up one or more users inside the users' OU.
+ *
+ * NOTE: objects can be nested; to nest an object and to establish implicit 
+ * dependency between containee and container, use the parent's DN and the
+ * new object's RDN to provide the new object's DN (DN=RDN,ParentDN).
+ */
+resource "ldap_object" "a123456" {
+	dn                  = "uid=a123456,${ldap_object.users_example_com.dn}"		
+	object_classes      = ["inetOrgPerson", "posixAccount"]
+	attributes          = [		
+		{ sn            = "Doe"}, 		
+		{ givenName		= "John"},
+		{ cn			= "John Doe"},
+		{ displayName	= "Mr. John K. Doe, esq."},
+		{ mail 			= "john.doe@example.com" },
+#		{ mail			= "a123456@internal.example.com" },
+		{ mail			= "jdoe@example.com" },
+		{ userPassword  = "password" },
+#		{ description	= "The best programmer in the world." },
+    	{ uidNumber     = "1234" },
+    	{ gidNumber     = "1234" },
+    	{ homeDirectory = "/home/jdoe"},
+    	{ loginShell    = "/bin/bash" }
+	]
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+func marshalObjectClasses(set map[string]struct{}) string {
+	list := make([]string, 0, len(set))
+	for item := range set {
+		list = append(list, item)
+	}
+	data, err := json.Marshal(list)
+	if err != nil {
+		return "[]"
+	}
+	s := string(data)
+	return s
+}
+
+func unmarshalObjectClasses(s string) map[string]struct{} {
+	var list []string
+	err := json.Unmarshal([]byte(s), &list)
+	set := make(map[string]struct{}, len(list))
+	if err != nil {
+		return set
+	}
+	for _, item := range list {
+		set[item] = struct{}{}
+	}
+	return set
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestObjectClassesRoundTrip(t *testing.T) {
+
+	tests := []map[string]struct{}{
+		map[string]struct{}{
+			"one":   struct{}{},
+			"two":   struct{}{},
+			"three": struct{}{},
+			"four":  struct{}{},
+			"five":  struct{}{},
+			"six":   struct{}{},
+		},
+
+		map[string]struct{}{
+			"unquoted":        struct{}{},
+			"\"quoted\"":      struct{}{},
+			"  with blanks  ": struct{}{},
+		},
+	}
+
+	for _, test := range tests {
+		set := unmarshalObjectClasses(marshalObjectClasses(test))
+		if len(test) != len(set) {
+			t.Error("for", test, "result was", set)
+		}
+		for item := range test {
+			if _, ok := set[item]; !ok {
+				t.Error("for", test, "item", item, "is missing")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hi @Pryz ,
these last two weeks I've been working on an extensive set of enhancements to your provider.
I'll be using my version in a production project soon and I tested it quite extensively; I will also try to thrust it onto Hashicorp and see if they want to adopt it under their "builtins"; would it be a problem for you? this code is only partly mine and it would not be there if you didn't publish yours first...

Once I started coding, there was very little I didn't touch but you may still want to pull it anyway, or at least give me an opinion on what you think of my modifications. I'm no LDAP guru and I'm learning terraform, so any feedback is really appreciated.
  
Like @kasimon said in his issue #3  the use of base_dn is a problem for a bunch of reasons: 
1. the DN is actually the object's RDN, and the BaseDn is the DN of the parent object; as far as I know, the base DN should be the set of DCs one uses at the top of the tree, not the parent's DN...
2. in the internal LDAP searches you're starting from the BaseDN and you look up the whole subtree for an object whose RDN is "foo", but there might be multiple since the visit is recursive; what then?
3. by searching the whole subtree you don't exploit the "search by primary key" feature that you have by using a nil DN, the DN as baseDN and the base object scope:
```
request := ldap.NewSearchRequest(
		dn,
		ldap.ScopeBaseObject,
		ldap.NeverDerefAliases,
		0,
		0,
		false,
		"(objectClass=*)",
		nil,
		nil,
	)
```
4. you can actually omit ```base_dn``` altogether and use a complete DN, which would also allow you to create nested objects, with inner objects referencing their parent's DN like this: ```dn = "uid=bar,${ldap_object.foo.dn}"```; by the way this creates implicit dependency so objects are created in the proper order;
5. once you have the DN, you can use it instead of a random int as the argument to ```d.SetId(db)``` in terraform's state;
6. update was missing, and I needed it so I implemented it (it was not easy with multivalued attributes!)
7. destroying and recreating an object to update it is a big problem when that object contains other objects (e.g. a OU containing users); my update is surgical and in place; only changes to the DN force the creation of a new objct; 
8. the syntax for representing attributes ("name" and "value") looked a bit cumbersome, so I defined my own format; it was more difficult than expected because I discovered along the way that HCL does not support a map of lists (map[string][]string, to encode ```"attribute" = ["value1", "value2", ... "valueN"]```) and I had to resort to a set of 1-element maps: unfortunate but still easier to write and read;
9. I modified the docker-compose tests to have phpldapadmin available on localhost too so you can run your tests and verify the results via GUI in a second. 

I know this is a load of stuff, I hope you'll appreciate or at least provide your feedback.

With my modifications, I guess issue #3 could be considered fixed: an example is in the tests.

TODO: I still need to more intimately understand and fix the acceptance tests for terraform plugins.

