### PR TITLE
Lazily initialize and bind the connection.

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"sync"
 
 	"gopkg.in/ldap.v2"
 )
@@ -16,29 +17,46 @@ type Config struct {
 	BindPassword string
 }
 
+// The lazily initialized response from the first initiateAndBind attempt.
+var initiateAndBindResponse *InitiateAndBindResponse
+var once sync.Once
+
+type InitiateAndBindResponse struct {
+	Connection *ldap.Conn
+	Err        error
+}
+
 func (c *Config) initiateAndBind() (*ldap.Conn, error) {
-	// TODO: should we handle UDP ?
-	connection, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", c.LDAPHost, c.LDAPPort))
-	if err != nil {
-		return nil, err
-	}
+	once.Do(func() {
+		initiateAndBindResponse = &InitiateAndBindResponse{}
 
-	// handle TLS
-	if c.UseTLS {
-		//TODO: Finish the TLS integration
-		err = connection.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		// TODO: should we handle UDP ?
+		connection, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", c.LDAPHost, c.LDAPPort))
 		if err != nil {
-			return nil, err
+			initiateAndBindResponse.Err = err
+			return
 		}
-	}
 
-	// bind to current connection
-	err = connection.Bind(c.BindUser, c.BindPassword)
-	if err != nil {
-		connection.Close()
-		return nil, err
-	}
+		// handle TLS
+		if c.UseTLS {
+			//TODO: Finish the TLS integration
+			err = connection.StartTLS(&tls.Config{InsecureSkipVerify: true})
+			if err != nil {
+				connection.Close()
+				initiateAndBindResponse.Err = err
+				return
+			}
+		}
 
-	// return the LDAP connection
-	return connection, nil
+		// bind to current connection
+		err = connection.Bind(c.BindUser, c.BindPassword)
+		if err != nil {
+			connection.Close()
+			initiateAndBindResponse.Err = err
+		}
+
+		// return the LDAP connection
+		initiateAndBindResponse.Connection = connection
+	})
+	return initiateAndBindResponse.Connection, initiateAndBindResponse.Err
 }

--- a/provider.go
+++ b/provider.go
@@ -50,18 +50,11 @@ func Provider() terraform.ResourceProvider {
 }
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
-	config := Config{
+	return &Config{
 		LDAPHost:     d.Get("ldap_host").(string),
 		LDAPPort:     d.Get("ldap_port").(int),
 		UseTLS:       d.Get("use_tls").(bool),
 		BindUser:     d.Get("bind_user").(string),
 		BindPassword: d.Get("bind_password").(string),
-	}
-
-	connection, err := config.initiateAndBind()
-	if err != nil {
-		return nil, err
-	}
-
-	return connection, nil
+	}, nil
 }


### PR DESCRIPTION
This will avoid connecting/binding to LDAP if, for example, you have defined the ldap provider and some ldap resources in your terraform config, but the ldap resource count is 0  (say if the count was calculated dynamically).

Note that you can also now prevent the provider for prompting for bind credentials if you specify bogus credentials in the provider configuration (assuming the ldap resource counts are zero)

i.e. connecting/binding to LDAP is now only performed if absolutely required.